### PR TITLE
Improve the provide() handling

### DIFF
--- a/src/Extensions/SiteConfigExtension.php
+++ b/src/Extensions/SiteConfigExtension.php
@@ -78,8 +78,11 @@ class SiteConfigExtension extends DataExtension
      * Template method to provide implementation of analytics
      */
     public function ProvideAnalyticsImplementation() : ?DBHTMLText {
-        if($this->owner->GoogleTagManagerCode && ($inst = $this->getAnalyticsImplementation())) {
-            return $inst->provide($this->owner->GoogleTagManagerCode);
+        if($inst = $this->getAnalyticsImplementation()) {
+            $context = [
+                'SiteConfig' => $this->owner
+            ];
+            return $inst->provide($this->owner->GoogleTagManagerCode ?? '', $context);
         } else {
             return null;
         }

--- a/src/Services/AbstractAnalyticsService.php
+++ b/src/Services/AbstractAnalyticsService.php
@@ -43,8 +43,10 @@ abstract class AbstractAnalyticsService {
     /**
      * Add requirements or similar to the current request, return template variable
      * for inclusion in template, or null
+     * @param string $code the analytics indentification code e.g. the GA4 config value
+     * @param array $context an array of custom context values to assist the service
      */
-    abstract public function provide(string $code = '') : ?DBHTMLText;
+    abstract public function provide(string $code = '', array $context = []) : ?DBHTMLText;
 
     /**
      * Return an instance of the implementation based on the code provided

--- a/src/Services/GA3.php
+++ b/src/Services/GA3.php
@@ -27,7 +27,11 @@ class GA3 extends AbstractAnalyticsService {
     /**
      * Add requirements or similar to the current request
      */
-    public function provide(string $code = '') : ?DBHTMLText {
+    public function provide(string $code = '', array $context = []) : ?DBHTMLText {
+        if(!$code) {
+            // a code is required
+            return null;
+        }
         $code = json_encode(htmlspecialchars($code));
         $script =
 <<<JAVASCRIPT

--- a/src/Services/GA4.php
+++ b/src/Services/GA4.php
@@ -28,7 +28,11 @@ class GA4 extends AbstractAnalyticsService {
     /**
      * Add requirements or similar to the current request
      */
-    public function provide(string $code = '') : ?DBHTMLText {
+    public function provide(string $code = '', array $context = []) : ?DBHTMLText {
+        if(!$code) {
+            // a code is required
+            return null;
+        }
         // Set up inline script
         $gtagCode = $code;
         $code = json_encode(htmlspecialchars($code));

--- a/src/Services/GTM.php
+++ b/src/Services/GTM.php
@@ -27,7 +27,11 @@ class GTM extends AbstractAnalyticsService {
     /**
      * Add requirements or similar to the current request
      */
-    public function provide(string $code = '') : ?DBHTMLText {
+    public function provide(string $code = '', array $context = []) : ?DBHTMLText {
+        if(!$code) {
+            // a code is required
+            return null;
+        }
         $code = json_encode($code);
         $script =
 <<<JAVASCRIPT

--- a/src/Services/GTMNonce.php
+++ b/src/Services/GTMNonce.php
@@ -28,7 +28,11 @@ class GTMNonce extends GTM {
     /**
      * Add requirements or similar to the current request
      */
-    public function provide(string $code = '') : ?DBHTMLText {
+    public function provide(string $code = '', array $context = []) : ?DBHTMLText {
+        if(!$code) {
+            // a code is required
+            return null;
+        }
         $code = json_encode(htmlspecialchars($code));
         $script =
 <<<JAVASCRIPT


### PR DESCRIPTION
## Changes

+ Add a context array parameter to provide() to allow some context, currently current SiteConfig value, to be passed to the chosen provider.
+ Some analytics providers do not require a analytics service code, do not block loading of the script if so
+ All current services require a identifier code to deliver a script